### PR TITLE
1.0.1

### DIFF
--- a/GiantParticleFix/Plugin.cs
+++ b/GiantParticleFix/Plugin.cs
@@ -1,57 +1,20 @@
 ﻿using BepInEx;
 using RoR2;
-using UnityEngine;
-using System;
-using BepInEx.Configuration;
-using System.Runtime.CompilerServices;
-using UnityEngine.Networking;
-using UnityEngine.AddressableAssets;
 
 namespace GiantParticleFix
 {
-    [BepInDependency("com.rune580.riskofoptions", BepInDependency.DependencyFlags.SoftDependency)]
-    [BepInPlugin("com.Moffein.GiantParticleFix", "GiantParticleFix", "1.0.0")]
+    [BepInPlugin("com.Moffein.GiantParticleFix", "GiantParticleFix", "1.0.1")]
     public class GiantParticleFix : BaseUnityPlugin
     {
         public void Awake()
         {
-            On.RoR2.BurnEffectController.AddFireParticles += BurnEffectController_AddFireParticles;
+            On.RoR2.NormalizeParticleScale.OnEnable += ApplyEnableOnce;
         }
 
-        private GameObject BurnEffectController_AddFireParticles(On.RoR2.BurnEffectController.orig_AddFireParticles orig, BurnEffectController self, Renderer modelRenderer, Transform targetParentTransform)
+        private void ApplyEnableOnce(On.RoR2.NormalizeParticleScale.orig_OnEnable orig, NormalizeParticleScale self)
         {
-            GameObject toReturn =  orig(self, modelRenderer, targetParentTransform);
-            if (toReturn && toReturn.transform && modelRenderer && modelRenderer.transform)
-            {
-                float max = Mathf.Max(modelRenderer.transform.localScale.x , modelRenderer.transform.localScale.y, modelRenderer.transform.localScale.z);
-                if (max > 1f)
-                {
-                    NormalizeParticleScale nps = toReturn.GetComponent<NormalizeParticleScale>();
-                    if (nps)
-                    {
-                        ParticleSystem ps = toReturn.GetComponent<ParticleSystem>();
-                        if (ps)
-                        {
-                            ParticleSystem.MainModule main = ps.main;
-                            ParticleSystem.MinMaxCurve startSize = main.startSize;
-
-                            //Todo: figure out how to downscale spread range as well
-                            startSize.constantMin /= max;
-                            startSize.constantMax /= max;
-                            main.startSize = startSize; //need to do this to make changes actually apply
-                        }
-                    }
-                }
-            }
-            return toReturn;
+            if (!(bool)self.particleSystem)
+                orig(self);
         }
-    }
-}
-
-namespace R2API.Utils
-{
-    [AttributeUsage(AttributeTargets.Assembly)]
-    public class ManualNetworkRegistrationAttribute : Attribute
-    {
     }
 }


### PR DESCRIPTION
The core of the issue is the NormalizeParticleScale applying the OnEnable multiple times when the model turns invisible. Replaced the code with a hook that just checks if the particle system isnt assigned then run the OnEnable. So it runs only once and fixes the giant particles.